### PR TITLE
force phpredis version to 3.1.2

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN docker-php-ext-install xml
 RUN docker-php-ext-configure intl && docker-php-ext-install intl
-RUN pecl install redis \
+RUN pecl install redis-3.1.2 \
     && pecl install xdebug \
     && docker-php-ext-enable redis xdebug
 RUN docker-php-ext-install pdo_mysql


### PR DESCRIPTION
new version 3.1.3 has some problems with magento:
https://github.com/phpredis/phpredis/issues/1211